### PR TITLE
Correct alexsdutton's username

### DIFF
--- a/repositories.yml
+++ b/repositories.yml
@@ -22,7 +22,7 @@ orgs:
           - zzacharo
       inveniordm:
         members:
-          - alexdutton
+          - alexsdutton
           - baldemir
           - cfgamboa
           - dfdan
@@ -65,7 +65,7 @@ orgs:
         members:
           - aaccomazzi
           - adrianp
-          - alexdutton
+          - alexsdutton
           - alizeepace
           - anastass
           - andrewm89


### PR DESCRIPTION
My GitHub username has a hidden 's' in the middle, so this applies `s/alexdutton/alexsdutton/g`